### PR TITLE
fix CONTAINER_OF casting issues in i2c

### DIFF
--- a/samd21/hal/src/hal_i2c_m_sync.c
+++ b/samd21/hal/src/hal_i2c_m_sync.c
@@ -54,7 +54,11 @@
  */
 static int32_t i2c_m_sync_read(struct io_descriptor *io, uint8_t *buf, const uint16_t n)
 {
+    
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wcast-align"
 	struct i2c_m_sync_desc *i2c = CONTAINER_OF(io, struct i2c_m_sync_desc, io);
+        #pragma GCC diagnostic pop
 	struct _i2c_m_msg       msg;
 	int32_t                 ret;
 
@@ -77,7 +81,10 @@ static int32_t i2c_m_sync_read(struct io_descriptor *io, uint8_t *buf, const uin
  */
 static int32_t i2c_m_sync_write(struct io_descriptor *io, const uint8_t *buf, const uint16_t n)
 {
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wcast-align"
 	struct i2c_m_sync_desc *i2c = CONTAINER_OF(io, struct i2c_m_sync_desc, io);
+        #pragma GCC diagnostic pop
 	struct _i2c_m_msg       msg;
 	int32_t                 ret;
 

--- a/samd51/hal/src/hal_i2c_m_sync.c
+++ b/samd51/hal/src/hal_i2c_m_sync.c
@@ -54,7 +54,11 @@
  */
 static int32_t i2c_m_sync_read(struct io_descriptor *io, uint8_t *buf, const uint16_t n)
 {
+    
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wcast-align"
 	struct i2c_m_sync_desc *i2c = CONTAINER_OF(io, struct i2c_m_sync_desc, io);
+        #pragma GCC diagnostic pop
 	struct _i2c_m_msg       msg;
 	int32_t                 ret;
 
@@ -77,7 +81,10 @@ static int32_t i2c_m_sync_read(struct io_descriptor *io, uint8_t *buf, const uin
  */
 static int32_t i2c_m_sync_write(struct io_descriptor *io, const uint8_t *buf, const uint16_t n)
 {
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wcast-align"
 	struct i2c_m_sync_desc *i2c = CONTAINER_OF(io, struct i2c_m_sync_desc, io);
+        #pragma GCC diagnostic pop
 	struct _i2c_m_msg       msg;
 	int32_t                 ret;
 


### PR DESCRIPTION
This will look familiar to you. `CONTAINER_OF` causes casting warnings.

By the way, `CONTAINER_OF` is kind of awful, if you haven't looked at it in detail. You give it an inner field (like a struct) that's in an outer struct, and it gives you pointer for the outer struct. That's assuming that the inner field  really is inside some containing struct, and wasn't declared standalone.