### PR TITLE
usart fixes; clock setting improvments

### DIFF
--- a/samd21/hpl/core/hpl_init.c
+++ b/samd21/hpl/core/hpl_init.c
@@ -53,6 +53,8 @@
 
 /* Referenced GCLKs, should be initialized firstly
 */
+// CircuitPython: CIRCUITPY_GCLK_INIT_1ST is defined in asf4_conf/hpl_gclk_config.h
+// to specify which clocks to initialize first.
 #ifdef CIRCUITPY_GCLK_INIT_1ST
 #define _GCLK_INIT_1ST CIRCUITPY_GCLK_INIT_1ST
 #else
@@ -61,7 +63,7 @@
 #endif
 
 /* Not referenced GCLKs, initialized last */
-#ifdef CIRCUITPY_GCLK_INIT_1ST
+#ifdef CIRCUITPY_GCLK_INIT_LAST
 #define _GCLK_INIT_LAST CIRCUITPY_GCLK_INIT_LAST
 #else
 #define _GCLK_INIT_LAST (~_GCLK_INIT_1ST)

--- a/samd21/hpl/sercom/hpl_sercom.c
+++ b/samd21/hpl/sercom/hpl_sercom.c
@@ -1,4 +1,3 @@
-
 /**
  * \file
  *
@@ -56,6 +55,7 @@
 #include <utils.h>
 #include <utils_assert.h>
 
+// CircuitPython:
 // Use SERCOM settings as prototypes to set
 // the default settings. The asf4_conf/hpl_sercom_config.h file
 // defines these bindings, and chooses a SERCOM (listed as x here).
@@ -63,10 +63,15 @@
 // #define PROTOTYPE_SERCOM_SPI_M_SYNC SERCOMx
 // #define PROTOTYPE_SERCOM_I2CM_SYNC SERCOMx
 // #define PROTOTYPE_SERCOM_USART_ASYNC SERCOMx
-
+//
 // Use these to choose the right settings from the _spis, _i2cms, and _usarts tables.
 // Look up the prototype instance by using the prototype SERCOM addresses,
-// not the SERCOMnumber.
+// not the SERCOM number.
+//
+// Note that there are some mentions here of SERCOM6 and SERCOM7. These don't exist on SAMD21,
+// but were put here by Atmel START, and so some of the added code here may also mention these
+// for ease of comparison with the SAMD51 version of this code.
+
 
 #ifndef CONF_SERCOM_0_USART_ENABLE
 #define CONF_SERCOM_0_USART_ENABLE 0
@@ -180,7 +185,53 @@ static struct usart_configuration _usarts[] = {
 };
 #endif
 
+static struct _usart_async_device *_sercom0_dev = NULL;
+static struct _usart_async_device *_sercom1_dev = NULL;
 static struct _usart_async_device *_sercom2_dev = NULL;
+static struct _usart_async_device *_sercom3_dev = NULL;
+#ifdef SERCOM4
+static struct _usart_async_device *_sercom4_dev = NULL;
+#endif
+#ifdef SERCOM5
+static struct _usart_async_device *_sercom5_dev = NULL;
+#endif
+#ifdef SERCOM6
+static struct _usart_async_device *_sercom6_dev = NULL;
+#endif
+#ifdef SERCOM7
+static struct _usart_async_device *_sercom7_dev = NULL;
+#endif
+
+static struct {
+    Sercom *sercom;
+    struct _usart_async_device **sercom_dev;
+} sercom_to_sercom_dev[] = {
+    {SERCOM0, &_sercom0_dev},
+    {SERCOM1, &_sercom1_dev},
+    {SERCOM2, &_sercom2_dev},
+    {SERCOM3, &_sercom3_dev},
+#ifdef SERCOM4
+    {SERCOM4, &_sercom4_dev},
+#endif
+#ifdef SERCOM5
+    {SERCOM5, &_sercom5_dev},
+#endif
+#ifdef SERCOM6
+    {SERCOM6, &_sercom6_dev},
+#endif
+#ifdef SERCOM7
+    {SERCOM7, &_sercom7_dev},
+#endif
+};
+
+static struct _usart_async_device** get_dev_for_sercom(Sercom *sercom) {
+    for (size_t i = 0; i < (sizeof(sercom_to_sercom_dev) / sizeof(sercom_to_sercom_dev[0])); i++) {
+        if (sercom_to_sercom_dev[i].sercom == sercom) {
+            return sercom_to_sercom_dev[i].sercom_dev;
+        }
+    }
+    return NULL;
+}
 
 static uint8_t _get_sercom_index(const void *const hw);
 static uint8_t _sercom_get_irq_num(const void *const hw);
@@ -247,6 +298,9 @@ void _usart_async_deinit(struct _usart_async_device *const device)
 {
 	NVIC_DisableIRQ((IRQn_Type)_sercom_get_irq_num(device->hw));
 	_usart_deinit(device->hw);
+
+        // Break association between device handler and given sercom.
+        *(get_dev_for_sercom(device->hw)) = NULL;
 }
 
 /**
@@ -636,10 +690,8 @@ static uint8_t _get_sercom_index(const void *const hw)
  */
 static void _sercom_init_irq_param(const void *const hw, void *dev)
 {
-
-	if (hw == SERCOM2) {
-		_sercom2_dev = (struct _usart_async_device *)dev;
-	}
+    // Remember the hpl object that does with the sercom, for use by the interrupt handlers.
+    *(get_dev_for_sercom((Sercom *) hw)) = (struct _usart_async_device *)dev;
 }
 
 /**
@@ -1132,7 +1184,7 @@ int32_t _i2c_m_async_set_baudrate(struct _i2c_m_async_device *const i2c_dev, uin
 		return ERR_DENIED;
 	}
 
-	tmp     = _get_i2cm_index(hw);
+	tmp     = _get_i2cm_index(PROTOTYPE_SERCOM_I2CM_SYNC);
 	clkrate = _i2cms[tmp].clk / 1000;
 
 	if (i2c_dev->service.mode == I2C_STANDARD_MODE) {
@@ -1423,7 +1475,7 @@ int32_t _i2c_m_sync_set_baudrate(struct _i2c_m_sync_device *const i2c_dev, uint3
 		return ERR_DENIED;
 	}
 
-	tmp     = _get_i2cm_index(hw);
+	tmp     = _get_i2cm_index(PROTOTYPE_SERCOM_I2CM_SYNC);
 	clkrate = _i2cms[tmp].clk / 1000;
 
 	if (i2c_dev->service.mode == I2C_STANDARD_MODE) {
@@ -2385,10 +2437,32 @@ static inline const struct sercomspi_regs_cfg *_spi_get_regs(const uint32_t hw_a
 	return NULL;
 }
 
-void SERCOM2_Handler(void)
-{
+void SERCOM0_Handler(void) {
+	_sercom_usart_interrupt_handler(_sercom0_dev);
+}
+
+void SERCOM1_Handler(void) {
+	_sercom_usart_interrupt_handler(_sercom1_dev);
+}
+
+void SERCOM2_Handler(void) {
 	_sercom_usart_interrupt_handler(_sercom2_dev);
 }
+
+void SERCOM3_Handler(void) {
+	_sercom_usart_interrupt_handler(_sercom3_dev);
+}
+
+#ifdef SERCOM4
+void SERCOM4_Handler(void) {
+	_sercom_usart_interrupt_handler(_sercom4_dev);
+}
+#endif
+#ifdef SERCOM5
+void SERCOM5_Handler(void) {
+	_sercom_usart_interrupt_handler(_sercom5_dev);
+}
+#endif
 
 int32_t _spi_m_sync_init(struct _spi_m_sync_dev *dev, void *const hw)
 {

--- a/samd51/hpl/core/hpl_init.c
+++ b/samd51/hpl/core/hpl_init.c
@@ -50,13 +50,10 @@
 #include <hpl_dma.h>
 #include <hpl_dmac_config.h>
 
-// do GCLK 1, 5, 0, 3 first.
-// See hpl_gclk_config.h and hpl_oscctrl_config.h.
-// TODO: Perhaps this value should be defined in one of
-// those include files.
-
 /* Referenced GCLKs, should be initialized firstly
 */
+// CircuitPython: CIRCUITPY_GCLK_INIT_1ST is defined in asf4_conf/hpl_gclk_config.h
+// to specify which clocks to initialize first.
 #ifdef CIRCUITPY_GCLK_INIT_1ST
 #define _GCLK_INIT_1ST CIRCUITPY_GCLK_INIT_1ST
 #else
@@ -65,7 +62,7 @@
 #endif
 
 /* Not referenced GCLKs, initialized last */
-#ifdef CIRCUITPY_GCLK_INIT_1ST
+#ifdef CIRCUITPY_GCLK_INIT_LAST
 #define _GCLK_INIT_LAST CIRCUITPY_GCLK_INIT_LAST
 #else
 #define _GCLK_INIT_LAST (~_GCLK_INIT_1ST)


### PR DESCRIPTION
This PR is a prerequisite for the upcoming circuitpython UART PR (to update the asf4 submodule commit).

1. Choose which clocks to start when based on a #define from a config file (fixes bug in previous commit).
2. Provide interrupt handlers for all SERCOMs instead of just those specified in Atmel START.
3. Use prototypical SERCOM for usart.