### PR TITLE
Add Necessary FREQM Definition For Upcoming FrequencyIn Module

### DIFF
--- a/samd51/include/instance/freqm.h
+++ b/samd51/include/instance/freqm.h
@@ -55,5 +55,6 @@
 
 /* ========== Instance parameters for FREQM peripheral ========== */
 #define FREQM_GCLK_ID_MSR           5        // Index of measure generic clock
+#define FREQM_GCLK_ID_REF           6        // Index of reference generic clock
 
 #endif /* _SAMD51_FREQM_INSTANCE_ */


### PR DESCRIPTION
Adds the definition for `FREQM_GCLK_ID_REF`. Necessary for upcoming FrequencyIn module, and associated FREQM usage in `samd-peripherals` for SAMD51 (PR also imminent).